### PR TITLE
actions/checkoutをv2からv1に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     # Ubuntu OSを仮想マシン上に用意する
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       # Node.js環境のセットアップを行う
       - name: Setup node


### PR DESCRIPTION
The job could not retrieve the repository token.
のエラーが出たため、
https://www.yslibrary.net/2020/04/18/actions-checkout-v2-push/
を参考に設定を変更。