### PR TITLE
#10 Tailwindの設定

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,31 @@ module.exports = {
   purge: ["./src/**/*.{ts,tsx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    colors: {
+      k: {
+        gray: {
+          light: "#494949",
+          dark: "#666666",
+        },
+        navy: {
+          light: "#18283f",
+          dark: "#16212b",
+          black: "#151d21",
+        },
+        blue: {
+          light: "#3fa9f5",
+          dark: "#1b8eda",
+        },
+        sky: "#7db4e6",
+        pink: "#ed1e79",
+      },
+    },
+    extend: {
+      screens: {
+        "k-sm": "481px",
+        "k-lg": "960px",
+      },
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
独自定義のbreakpointやcolorはprefixを`k-`で統一しました。

colorsは入れ子になっていますが、`k-gray-light`のように指定することができます。
https://tailwindcss.com/docs/customizing-colors#color-object-syntax

This PR closes #10.