### PR TITLE
#31 404ページの作成

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import ArticleLayout from "src/components/templates/ArticleLayout";
+import Subtitle from "src/components/modules/Subtitle";
+
+export default function Custom404() {
+  return (
+    <>
+      <Head>
+        <title>2020年こうがく祭公式HP | 茨城大学</title>
+      </Head>
+      <article className="relative top-[calc(-1.2rem-26px)] k-lg:top-[calc(-1.2rem-27px)]">
+        <Subtitle text="404 NotFound" />
+        <p className="p-2 text-[1.5rem] k-lg:text-[1.8rem] mb-[50px]">
+          ページが存在しません。URLが間違っている可能性があります。
+          <br />
+          <Link href="/">
+            <a className="underline text-k-blue-dark">トップページへ</a>
+          </Link>
+        </p>
+      </article>
+    </>
+  );
+}
+
+Custom404.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <ArticleLayout titleJa="NotFound" titleEn="404">
+      {page}
+    </ArticleLayout>
+  );
+};


### PR DESCRIPTION
Closes #31 .

垂直な装飾見出しのテキストが昨年度版と異なりますが、手間をかけてまで変える必要があるとは思わなかったためそのままにしました。
また、リンクの文字の大きさも昨年度版とは異なり本文と同じ大きさにしています。
その他の点は昨年度版と同様です。