### PR TITLE
#29 お問い合わせページ作成

### DIFF
--- a/src/components/modules/SNSButtons.tsx
+++ b/src/components/modules/SNSButtons.tsx
@@ -13,7 +13,7 @@ const accounts = [
   },
   {
     title: "Instagram",
-    url: "#",
+    url: "https://www.instagram.com/kougakufes/",
     imagePath: "./instagram.png",
   },
   {

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,77 @@
+import { ReactElement } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import ArticleLayout from "src/components/templates/ArticleLayout";
+import Subtitle from "src/components/modules/Subtitle";
+
+const contacts = [
+  {
+    type: "メール",
+    name: "メールアドレス",
+    text: "kougakusai.1107@gmail.com",
+    link: "mailto:kougakusai.1107@gmail.com",
+  },
+  {
+    type: "Twitter",
+    name: "Twitter(DM)",
+    text: "@kougakufes",
+    link: "https://twitter.com/kougakufes/", //DMLink="https://twitter.com/messages/compose?recipient_id=User_ID"
+  },
+  {
+    type: "Instagram",
+    name: "Instagram(DM)",
+    text: "kougakufes",
+    link: "https://www.instagram.com/kougakufes/",
+  },
+  {
+    type: "匿名質問箱(Peing)",
+    name: "匿名質問箱",
+    text: "kougakufes",
+    link: "https://peing.net/ja/kougakufes/",
+  },
+];
+
+const Contact = () => {
+  return (
+    <>
+      <article className="text-[1.8rem]">
+        <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
+        <br />
+        <div className="space-y-[50px]">
+          {contacts.map(({ type, name, text, link }) => {
+            return (
+              <div key={type}>
+                <Subtitle text={name} />
+                <a
+                  onClick={() => {
+                    const jump: boolean = confirm(
+                      `${type}でこうがく祭へ連絡を取りますか？\n（${type}を開きます。）`
+                    );
+                    if (jump) {
+                      window.open(`${link}`, "_blank", "noreferrer");
+                    }
+                    return false;
+                  }}
+                >
+                  {text}
+                </a>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+    </>
+  );
+};
+
+Contact.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <ArticleLayout titleJa="お問い合わせ" titleEn="Contact">
+      {page}
+    </ArticleLayout>
+  );
+};
+
+export default Contact;
+
+// Confirmed Link ref="https://colo-ri.jp/develop/2010/03/javascriptconfirm.html"

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from "react";
 import Head from "next/head";
-import Link from "next/link";
 import ArticleLayout from "src/components/templates/ArticleLayout";
 import Subtitle from "src/components/modules/Subtitle";
 
@@ -33,32 +32,37 @@ const contacts = [
 
 const Contact = () => {
   return (
-    <article className="text-[1.8rem]">
-      <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
-      <br />
-      <div className="space-y-[50px]">
-        {contacts.map(({ type, name, text, link }) => {
-          return (
-            <div key={type}>
-              <Subtitle text={name} />
-              <a
-                onClick={() => {
-                  const jump: boolean = confirm(
-                    `${type}でこうがく祭へ連絡を取りますか？\n（${type}を開きます。）`
-                  );
-                  if (jump) {
-                    window.open(`${link}`, "_blank", "noreferrer");
-                  }
-                  return false;
-                }}
-              >
-                {text}
-              </a>
-            </div>
-          );
-        })}
-      </div>
-    </article>
+    <>
+      <Head>
+        <title>2020年こうがく祭公式HP | 茨城大学</title>
+      </Head>
+      <article className="text-[1.8rem]">
+        <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
+        <br />
+        <div className="space-y-[50px]">
+          {contacts.map(({ type, name, text, link }) => {
+            return (
+              <div key={type}>
+                <Subtitle text={name} />
+                <a
+                  onClick={() => {
+                    const jump: boolean = confirm(
+                      `${type}でこうがく祭へ連絡を取りますか？\n（${type}を開きます。）`
+                    );
+                    if (jump) {
+                      window.open(`${link}`, "_blank", "noreferrer");
+                    }
+                    return false;
+                  }}
+                >
+                  {text}
+                </a>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+    </>
   );
 };
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -36,8 +36,10 @@ const Contact = () => {
       <Head>
         <title>2020年こうがく祭公式HP | 茨城大学</title>
       </Head>
-      <article className="text-[1.8rem]">
-        <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
+      <article className="text-[1.5rem] k-lg:text-[1.8rem] relative top-[calc(-1.2rem-26px)] k-lg:top-[calc(-1.2rem-27px)]">
+        <p className="p-2">
+          質問等があれば下記連絡先へお気軽にお問い合わせください。
+        </p>
         <br />
         <div className="space-y-[50px]">
           {contacts.map(({ type, name, text, link }) => {
@@ -55,7 +57,7 @@ const Contact = () => {
                     return false;
                   }}
                 >
-                  {text}
+                  <p className="p-2">{text}</p>
                 </a>
               </div>
             );

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -33,34 +33,32 @@ const contacts = [
 
 const Contact = () => {
   return (
-    <>
-      <article className="text-[1.8rem]">
-        <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
-        <br />
-        <div className="space-y-[50px]">
-          {contacts.map(({ type, name, text, link }) => {
-            return (
-              <div key={type}>
-                <Subtitle text={name} />
-                <a
-                  onClick={() => {
-                    const jump: boolean = confirm(
-                      `${type}でこうがく祭へ連絡を取りますか？\n（${type}を開きます。）`
-                    );
-                    if (jump) {
-                      window.open(`${link}`, "_blank", "noreferrer");
-                    }
-                    return false;
-                  }}
-                >
-                  {text}
-                </a>
-              </div>
-            );
-          })}
-        </div>
-      </article>
-    </>
+    <article className="text-[1.8rem]">
+      <p>質問等があれば下記連絡先へお気軽にお問い合わせください。</p>
+      <br />
+      <div className="space-y-[50px]">
+        {contacts.map(({ type, name, text, link }) => {
+          return (
+            <div key={type}>
+              <Subtitle text={name} />
+              <a
+                onClick={() => {
+                  const jump: boolean = confirm(
+                    `${type}でこうがく祭へ連絡を取りますか？\n（${type}を開きます。）`
+                  );
+                  if (jump) {
+                    window.open(`${link}`, "_blank", "noreferrer");
+                  }
+                  return false;
+                }}
+              >
+                {text}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </article>
   );
 };
 


### PR DESCRIPTION
Close #29 .

昨年度を参考に、内容を更新。

1. Instagramのリンク追加（#29とは関係ないですけど、発見したので。）
2. 表示する連絡先はPR村に確認してもらいたい。
3. pageの関数を`Arrow関数`で記述（公式もページコンポーネントのみ`function`で書いてるけど、`Arrow関数`で統一したい。エラーは出ない）
4. 連絡先をリンクありにする挑戦（不適ならば削除）