### PR TITLE
お知らせの改行位置の修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,13 +13,10 @@ const announcement = [
     detail: "こうがく祭開催予定",
   },
   {
-    date: "10月26日", // TODO 公開直前に日付を更新
+    date: "10月26日",
     detail: "2021年度版HPを公開しました。",
   },
 ];
-
-const startTime = "2021-11-06T10:00:00+0900";
-const endTime = "2021-11-06T15:00:00+0900";
 
 const headline = (
   <span
@@ -37,71 +34,6 @@ const headline = (
   </span>
 );
 
-// {
-//   //背景画像文字
-//   //開催前
-//   before: (
-//     <span
-//       className={clsx(
-//         'mt-[-35%] k-sm:mt-[-20%] k-lg:mt-[-18%]',
-//         'pl-[25vw] k-sm:pl-[6vw] k-lg:pl-[3vw]',
-//         'w-10/12 k-sm:w-3/4 k-lg:w-full float-left',
-//         'text-[8vw] k-sm:text-[6vw] k-lg:text-[2.8vw] text-center leading-normal tracking-widest',
-//         'text-yellow-200 brightness-125 blur-[0.8px] font-bold'
-//       )}
-//     >
-//       オンライン開催
-//       <br />
-//       11月06日(土) 10:00配信開始
-//     </span>
-//   ),
-//   //開催中
-//   inSession: (
-//     <span
-//       className={clsx(
-//         'mt-[-35%] k-sm:mt-[-20%] k-lg:mt-[-18%]',
-//         'pl-[30vw] k-sm:pl-[14vw] k-lg:pl-[5vw]',
-//         'w-10/12 k-sm:w-3/4 k-lg:w-full float-left',
-//         'text-[8vw] k-sm:text-[5vw] k-lg:text-[3vw] text-center leading-normal tracking-widest',
-//         'text-yellow-200 brightness-125 blur-[0.8px] font-bold'
-//       )}
-//     >
-//       オンライン開催
-//       <br />
-//       YouTubeLiveで配信中
-//     </span>
-//   ),
-//   //開催後
-//   after: (
-//     <span
-//       className={clsx(
-//         'mt-[-35%] k-sm:mt-[-18%] k-lg:mt-[-12%]',
-//         'pl-[20vw] k-sm:pl-[5vw] k-lg:pl-0 k-lg:ml-[-8%]',
-//         'w-[90%] k-sm:w-3/4 k-lg:w-full float-left',
-//         'text-[7vw] k-sm:text-[4.7vw] k-lg:text-[2.6vw] text-center leading-normal tracking-widest',
-//         'text-yellow-200 brightness-125 blur-[0.8px] font-bold'
-//       )}
-//     >
-//       2021年こうがく祭は終了しました
-//       <br />
-//       ご覧いただいた皆様ありがとうございました
-//     </span>
-//   ),
-// };
-
-// const headlineDate = () => {
-//   if (new Date().getTime() < new Date(startTime).getTime()) {
-//     //開催前
-//     return headline.before;
-//   } else if (new Date().getTime() < new Date(endTime).getTime()) {
-//     //開催中
-//     return headline.inSession;
-//   } else {
-//     //開催後
-//     return headline.after;
-//   }
-// };
-
 export default function Home() {
   return (
     <>
@@ -109,7 +41,6 @@ export default function Home() {
         <title>2021年こうがく祭公式HP | 茨城大学</title>
       </Head>
       <main>
-        {/* TODO 背景画像内の日付更新 */}
         <div
           className={clsx(
             "w-full h-0 pt-[200%] bg-center bg-cover bg-no-repeat k-sm:hidden",
@@ -137,7 +68,6 @@ export default function Home() {
             alt="こうがく祭"
             className="w-full k-sm:w-[58vw] k-lg:w-[40vw]"
           />
-          {/* {headlineDate()} */}
           {headline}
         </h1>
         <article

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -94,16 +94,16 @@ export default function Home() {
           </section>
           <section>
             <Subtitle text="お知らせ" />
-            <ul>
+            <table>
               {announcement.map(({ date, detail }) => {
                 return (
-                  <li className="h-[38px] leading-[38px]" key={date}>
-                    <span className="w-[150px] mr-[30px]">{date}</span>
-                    <span>{detail}</span>
-                  </li>
+                  <tr key={date} className="align-text-top leading-[28px]">
+                    <td className="whitespace-nowrap pr-[30px]">{date}</td>
+                    <td className="pb-[10px]">{detail}</td>
+                  </tr>
                 );
               })}
-            </ul>
+            </table>
           </section>
         </article>
       </main>


### PR DESCRIPTION
Closes #68 .

`table`を使用して、お知らせの文章が改行時に日付の下まで回り込まないよう修正しました。

日付は改行されないよう`whitespace-nowrap`を指定しました。
改行時の行間を小さくするために`leading`を小さくした分、`pb`で要素間のスペースを確保しています。