### PR TITLE
#70 モバイル版フッターの高さ修正

### DIFF
--- a/src/components/modules/Footer/Footer.tsx
+++ b/src/components/modules/Footer/Footer.tsx
@@ -32,7 +32,7 @@ const Footer: VFC = () => {
       className={clsx(
         "k-lg:ml-auto w-full k-lg:w-[calc(100%-20vw)]",
         "bg-k-navy-black text-white text-[1.8rem]",
-        "px-[10%] pt-[10%] pb-[130px] k-lg:py-[5%] k-lg:pl-[7%] k-lg:pr-[20%]"
+        "px-[10%] pt-[10%] pb-[180px] k-lg:py-[5%] k-lg:pl-[7%] k-lg:pr-[20%] k-lg:pb-[130px]"
       )}
     >
       <div>


### PR DESCRIPTION
Closes #70 .

モバイル版のみフッターの`pb`を増やし、ナビゲーションの文字が被らないように調整。