### PR TITLE
npm scriptsの修正 #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ $ yarn dev
 
 ### 静的サイトとして動作確認する場合
 
-次のコマンドで静的サイトを生成可能です。
+次のコマンドで静的サイトを生成・起動可能です。
 
 ```
-$ yarn run gen
+$ yarn start
 ```
 
-生成後は`out/index.html`を開くことで静的サイトが閲覧できます。
+起動後は[http://localhost:3000](http://localhost:3000)にアクセスすることでサイトが閲覧できます。
 
 ## Available Scripts
 
@@ -44,7 +44,7 @@ $ yarn run gen
 
 GitHub Pages にデプロイされるものと同じ状態なので、ローカルで確認したい場合に使用してください。
 
-### `yarn run fix`
+### `yarn fix`
 
 `src/`配下の`.ts`、`.tsx`ファイルに対して静的解析と整形を行います。
 
@@ -53,7 +53,7 @@ VSCode で編集している場合は保存時に自動実行されるように�
 ## Notes
 
 - `npm`は使用できません。`yarn`を使用してください。
-- VSCode に ESLint と Prettier の拡張機能を導入のうえ編集することをお勧めします。その他のエディタで編集する場合は、コミット前に必ず`yarn run fix`で整形するようにしてください。
+- VSCode に ESLint と Prettier の拡張機能を導入のうえ編集することをお勧めします。その他のエディタで編集する場合は、コミット前に必ず`yarn fix`で整形するようにしてください。
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "yarn build && next start",
     "export": "next export",
-    "gen": "yarn run build && yarn run export",
+    "gen": "yarn build && yarn export",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}'",
     "lint:next": "next lint --dir src",
     "fmt": "prettier --check 'src/**/*.{ts,tsx}'",
     "fmt:fix": "prettier --write 'src/**/*.{ts,tsx}'",
-    "fix": "yarn run fmt:fix && yarn run lint:fix"
+    "fix": "yarn fmt:fix && yarn lint:fix"
   },
   "dependencies": {
     "@types/react-transition-group": "^4.4.3",


### PR DESCRIPTION
Closes #110 .

`yarn`でnpm scriptsを実行する際、`run`は必須ではなかったため削除しました。