### PR TITLE
blurをtext-shadowに変更

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,7 +25,7 @@ const headline = (
       "pl-[20vw] k-sm:pl-[0vw] k-lg:pl-[0vw]",
       " float-left",
       "text-[5vw] k-sm:text-[4.5vw] k-lg:text-[2.8vw] text-center leading-normal tracking-widest",
-      "text-yellow-200 brightness-125 blur-[0.8px] font-bold "
+      "text-yellow-200 brightness-125 text-shadow-lg font-bold "
     )}
   >
     2021年の開催は終了しました。
@@ -47,7 +47,7 @@ const headline = (
               clipRule="evenodd"
             />
           </svg>
-          <span>企画を見る</span>
+          <span className="text-shadow-none">企画を見る</span>
         </a>
       </Link>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,5 +32,27 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    ({ addUtilities }) => {
+      const newUtilities = {
+        ".text-shadow": {
+          "text-shadow": "1px 0px 10px",
+        },
+        ".text-shadow-md": {
+          "text-shadow": "1px 0px 15px",
+        },
+        ".text-shadow-lg": {
+          "text-shadow": "1px 0px 20px",
+        },
+        ".text-shadow-xl": {
+          "text-shadow": "1px 0px 30px",
+        },
+        ".text-shadow-none": {
+          "text-shadow": "0px 0px 0px",
+        },
+      };
+
+      addUtilities(newUtilities);
+    },
+  ],
 };


### PR DESCRIPTION
`blur`が読みづらかったので`text-shadow`に変更してみました。
cssで定義せず、tailwindのutilityとして追加しています。

採用するかどうかはお任せしますので、不採用であればマージせずCloseしてください。